### PR TITLE
Added CORS to server and added template docs we need.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.X.X] - 201X-XX-XX
+### Added
+- Standard Volentix OS component integration.
+
+### Changed
+- None
+
+### Removed
+- None

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Contributor Code of Conduct
+
+Refer to the [Volentix Standard Code Of Conduct](https://github.com/Volentix/documentation/blob/master/CODE_OF_CONDUCT.md)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) 2019 Volentix and its contributors. All rights reserved.
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL VOLENTIX OR ANY OTHER AUTHORS OR COPYRIGHT HOLDERS OR ANY RELATED ENTITIES BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,3 @@
+# Roadmap
+
+TODO: Create roadmap.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policies and Procedures
+
+Refer to the [Volentix Standard Security Policy](https://github.com/Volentix/documentation/blob/master/SECURITY.md)

--- a/docker/api/http_server.py
+++ b/docker/api/http_server.py
@@ -51,6 +51,9 @@ class HTTPServer(resource.Resource):
     def render_GET(self, req):
         uri = req.uri[1:].decode().rsplit('?', 1)[0]
         if uri == 'getConnectedNodes':
+           req.setHeader('Access-Control-Allow-Origin', '*')
+           req.setHeader('Access-Control-Allow-Methods', 'GET')
+           req.setHeader('Content-type', 'application/json')
            result={'Result':'Success'}
            try:
              f = open(self.nodes_file, "r")


### PR DESCRIPTION
# PR Details

Added the CORS header stuff so that the page can load in Verto. Also added the docs that where missing.

## Checklist

Before submitting this PR, please ensure that the following has been completed.

- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the **CONTRIBUTING** document.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

You cannot get the request in Verto because the CORS headers required (due to a Chromium security thing) are not present. I added the header to the http server file. Should be reviewed and tightened up as I only need it for local host for now.

Additionally, I needed to have the standard docs present in the repo so I added them in this pull request.

## Motivation and Context

Call VDex from Verto

## How Has This Been Tested

I have deployed it into the k3s cluster on my laptop and then had Verto access the Json over the network.
