### PR TITLE
dependencies: use savoirfairelinux/opendht instead of AmarOk1412/opendht

### DIFF
--- a/docker/api/Cargo.toml
+++ b/docker/api/Cargo.toml
@@ -11,7 +11,7 @@ zk-paillier = { git = "https://github.com/KZen-networks/zk-paillier"}
 env_logger = "0.5.6"
 hex = "0.3.2"
 log = "0.4.1"
-opendht = { git = "https://github.com/AmarOk1412/opendht/", branch="feat/rust" }
+opendht = { git = "https://github.com/savoirfairelinux/opendht/" }
 rocket = "0.4.2"
 rocket_contrib = "0.4.2"
 rocket_cors = { git = "https://github.com/lawliet89/rocket_cors", branch = "master" }


### PR DESCRIPTION
The PR for new Rust APIs was merged
